### PR TITLE
Check for lines of text before getting first line in check_spellwarn_comment

### DIFF
--- a/lua/spellwarn/spelling.lua
+++ b/lua/spellwarn/spelling.lua
@@ -11,7 +11,7 @@ end
 function M.check_spellwarn_comment(bufnr, linenr) -- Check for spellwarn:disable* comments
     local above = (linenr > 1 and vim.api.nvim_buf_get_lines(bufnr, linenr - 2, linenr - 1, false)[1]) or ""
     local above_val = string.find(above, "spellwarn:disable-next-line", 1, true) ~= nil
-    local cur = vim.api.nvim_buf_get_lines(bufnr, linenr - 1, linenr, false)[1]
+    local cur = vim.api.nvim_buf_get_lines(bufnr, linenr - 1, linenr, false)[1] or ""
     local cur_val = string.find(cur, "spellwarn:disable-line", 1, true) ~= nil
     return above_val or cur_val
 end


### PR DESCRIPTION
First off, let me just say this is a great plugin. Exactly what I needed.

The reson for this pull request is to fix an error I was having when loading certain buffers, where it would call the `check_spellwarn_comment` function (in **spelling.lua** file), passing a buffer without any text.

This caused `vim.api.nvim_buf_get_lines` to return an empty array, but since the code assumes it will have something, and thus tries to get the first element, the variable "`cur`"  ends up as "`nil`"

When the "string.find" function gets called, it throws an error stating that the first argument cannot be nil.

This pull request just checks for a value in the first element, and if it is "nil", it places an empty string instead.