### PR TITLE
Fixes to spelling suggestions

### DIFF
--- a/lua/spellwarn/diagnostics.lua
+++ b/lua/spellwarn/diagnostics.lua
@@ -94,7 +94,7 @@ function M.setup(opts)
             elseif arg == "toggle" then
                 M.toggle()
             else
-                vim.api.nvim_err_writeln("Invalid argument: " .. arg)
+                vim.api.nvim_echo({ { "Invalid argument: " .. arg .. "\n" } }, true, { err = true })
             end
         end,
         { nargs = 1, complete = function() return { "disable", "enable", "toggle" } end }

--- a/lua/spellwarn/diagnostics.lua
+++ b/lua/spellwarn/diagnostics.lua
@@ -21,9 +21,9 @@ function M.update_diagnostics(opts, bufnr)
     end
     local diags = {}
     for _, error in pairs(require("spellwarn.spelling").get_spelling_errors_main(opts, bufnr) or {}) do
-        local suggestions = vim.fn.spellsuggest(error.word)
         local msg = opts.prefix .. error.word
         if opts.suggest and opts.num_suggest > 0 then
+            local suggestions = vim.fn.spellsuggest(error.word)
             local addition = "\nSuggestions:\n"
             for i = 1, opts.num_suggest do
                 if suggestions[i] then

--- a/lua/spellwarn/diagnostics.lua
+++ b/lua/spellwarn/diagnostics.lua
@@ -23,7 +23,7 @@ function M.update_diagnostics(opts, bufnr)
     for _, error in pairs(require("spellwarn.spelling").get_spelling_errors_main(opts, bufnr) or {}) do
         local msg = opts.prefix .. error.word
         if opts.suggest and opts.num_suggest > 0 then
-            local suggestions = vim.fn.spellsuggest(error.word)
+            local suggestions = vim.fn.spellsuggest(error.word, opts.num_suggest)
             local addition = "\nSuggestions:\n"
             for i = 1, opts.num_suggest do
                 if suggestions[i] then


### PR DESCRIPTION
Changes:
- Moved one line to make `spellsuggest` call (which in my case can be ultra slow) to only happen if suggestions are enabled
- I added to `spellsuggest` call max number of suggestion to get
- I changed deprecated `nvim_err_writeln` into `nvim_echo` call (This change I can fully remove from PR if you want because it's something completely out of topic of rest of this PR)

Context:
After updating my plugins I noticed that if I tried opening one of my configs that my NeoVim hang and used all of my CPU. After checking every plugin update separately I found that it was spellwarn. When I checked code it looked like this `spellsuggest` line was out of place (it was before if when its only used inside the if) and otherwise nothing that could indicate problems. After moving this line my NeoVim lived again in this specific file. (This config file was Ghostty Config which has 200 spelling errors apparently and `spellsuggest` this many times I guess was ultra slow)