### PR TITLE
Fixes: Removed diagnostics reset, added keepjumps. Stylua formatting.

### DIFF
--- a/lua/spellwarn/diagnostics.lua
+++ b/lua/spellwarn/diagnostics.lua
@@ -42,7 +42,7 @@ function M.update_diagnostics(opts, bufnr)
         if error.word ~= "" and error.word ~= "spellwarn" then
             if opts.severity[error.type] then
                 diags[#diags + 1] = {
-                    col = error.col - 1, -- 0-indexed
+                    col = error.col - 1,   -- 0-indexed
                     lnum = error.lnum - 1, -- 0-indexed
                     message = msg,
                     severity = vim.diagnostic.severity[opts.severity[error.type]],
@@ -61,7 +61,11 @@ function M.setup(opts)
         vim.api.nvim_create_autocmd(opts.event, {
             group = "Spellwarn",
             callback = function()
-                M.update_diagnostics(opts, vim.fn.bufnr("%"))
+                vim.schedule(
+                    function()
+                        M.update_diagnostics(opts, vim.fn.bufnr("%"))
+                    end
+                )
             end,
             desc = "Update Spellwarn diagnostics",
         })

--- a/lua/spellwarn/diagnostics.lua
+++ b/lua/spellwarn/diagnostics.lua
@@ -42,7 +42,7 @@ function M.update_diagnostics(opts, bufnr)
         if error.word ~= "" and error.word ~= "spellwarn" then
             if opts.severity[error.type] then
                 diags[#diags + 1] = {
-                    col = error.col - 1,   -- 0-indexed
+                    col = error.col - 1, -- 0-indexed
                     lnum = error.lnum - 1, -- 0-indexed
                     message = msg,
                     severity = vim.diagnostic.severity[opts.severity[error.type]],
@@ -62,7 +62,7 @@ function M.setup(opts)
             group = "Spellwarn",
             callback = function()
                 local winid = vim.api.nvim_get_current_win()
-                local bufnr = vim.fn.bufnr('%')
+                local bufnr = vim.fn.bufnr("%")
                 if winid then
                     if not vim.wo[winid].spell then
                         vim.diagnostic.reset(namespace, bufnr) -- ensure old are cleared if spell is toggled to off.
@@ -70,11 +70,7 @@ function M.setup(opts)
                     end
                 end
 
-                vim.schedule(
-                    function()
-                        M.update_diagnostics(opts, vim.fn.bufnr("%"))
-                    end
-                )
+                M.update_diagnostics(opts, bufnr)
             end,
             desc = "Update Spellwarn diagnostics",
         })

--- a/lua/spellwarn/diagnostics.lua
+++ b/lua/spellwarn/diagnostics.lua
@@ -61,6 +61,15 @@ function M.setup(opts)
         vim.api.nvim_create_autocmd(opts.event, {
             group = "Spellwarn",
             callback = function()
+                local winid = vim.api.nvim_get_current_win()
+                local bufnr = vim.fn.bufnr('%')
+                if winid then
+                    if not vim.wo[winid].spell then
+                        vim.diagnostic.reset(namespace, bufnr) -- ensure old are cleared if spell is toggled to off.
+                        return
+                    end
+                end
+
                 vim.schedule(
                     function()
                         M.update_diagnostics(opts, vim.fn.bufnr("%"))

--- a/lua/spellwarn/diagnostics.lua
+++ b/lua/spellwarn/diagnostics.lua
@@ -48,7 +48,6 @@ function M.update_diagnostics(opts, bufnr)
             end
         end
     end
-    vim.diagnostic.reset(namespace, bufnr)
     -- TODO: Add suffix diagnostics with type of spelling error the way that LSP diagnostics do
     vim.diagnostic.set(namespace, bufnr, diags, opts.diagnostic_opts)
 end

--- a/lua/spellwarn/diagnostics.lua
+++ b/lua/spellwarn/diagnostics.lua
@@ -13,7 +13,9 @@ end
 
 -- PERF: try wrapping this with a function to make it run asynchronously?
 function M.update_diagnostics(opts, bufnr)
-    if opts.max_file_size and vim.api.nvim_buf_line_count(bufnr) > opts.max_file_size then return end
+    if opts.max_file_size and vim.api.nvim_buf_line_count(bufnr) > opts.max_file_size then
+        return
+    end
     local ft = vim.fn.getbufvar(bufnr, "&filetype")
     if opts.ft_config[ft] == false or (opts.ft_config[ft] == nil and opts.ft_default == false) then
         vim.diagnostic.reset(namespace, bufnr)
@@ -35,15 +37,16 @@ function M.update_diagnostics(opts, bufnr)
                 end
             end
             msg = msg .. addition
+            msg = "!"
         end
         if error.word ~= "" and error.word ~= "spellwarn" then
             if opts.severity[error.type] then
                 diags[#diags + 1] = {
-                    col      = error.col - 1, -- 0-indexed
-                    lnum     = error.lnum - 1, -- 0-indexed
-                    message  = msg,
+                    col = error.col - 1, -- 0-indexed
+                    lnum = error.lnum - 1, -- 0-indexed
+                    message = msg,
                     severity = vim.diagnostic.severity[opts.severity[error.type]],
-                    source   = "spellwarn",
+                    source = "spellwarn",
                 }
             end
         end
@@ -57,7 +60,9 @@ function M.setup(opts)
         vim.api.nvim_create_augroup("Spellwarn", {})
         vim.api.nvim_create_autocmd(opts.event, {
             group = "Spellwarn",
-            callback = function() M.update_diagnostics(opts, vim.fn.bufnr("%")) end,
+            callback = function()
+                M.update_diagnostics(opts, vim.fn.bufnr("%"))
+            end,
             desc = "Update Spellwarn diagnostics",
         })
         for _, bufnr in pairs(get_bufs_loaded()) do
@@ -82,22 +87,23 @@ function M.setup(opts)
         end
     end
 
-    vim.api.nvim_create_user_command(
-        "Spellwarn",
-        function(args)
-            local arg = args.args
-            if arg == "enable" then
-                M.enable()
-            elseif arg == "disable" then
-                M.disable()
-            elseif arg == "toggle" then
-                M.toggle()
-            else
-                vim.api.nvim_echo({ { "Invalid argument: " .. arg .. "\n" } }, true, { err = true })
-            end
+    vim.api.nvim_create_user_command("Spellwarn", function(args)
+        local arg = args.args
+        if arg == "enable" then
+            M.enable()
+        elseif arg == "disable" then
+            M.disable()
+        elseif arg == "toggle" then
+            M.toggle()
+        else
+            vim.api.nvim_echo({ { "Invalid argument: " .. arg .. "\n" } }, true, { err = true })
+        end
+    end, {
+        nargs = 1,
+        complete = function()
+            return { "disable", "enable", "toggle" }
         end,
-        { nargs = 1, complete = function() return { "disable", "enable", "toggle" } end }
-    )
+    })
 
     if opts.enable then
         M.enable()

--- a/lua/spellwarn/diagnostics.lua
+++ b/lua/spellwarn/diagnostics.lua
@@ -37,7 +37,6 @@ function M.update_diagnostics(opts, bufnr)
                 end
             end
             msg = msg .. addition
-            msg = "!"
         end
         if error.word ~= "" and error.word ~= "spellwarn" then
             if opts.severity[error.type] then

--- a/lua/spellwarn/init.lua
+++ b/lua/spellwarn/init.lua
@@ -2,11 +2,8 @@ local M = {}
 local defaults = {
     -- FIX: Trouble.nvim jump to diagnostic is slightly buggy with `TextChanged` event; no good workaround though AFAICT
     event = { -- event(s) to refresh diagnostics on
-        "CursorHold",
-        "InsertLeave",
         "TextChanged",
-        "TextChangedI",
-        "TextChangedP",
+        "InsertLeave",
     },
     enable = true, -- enable diagnostics on startup
     ft_config = { -- spellcheck method: "cursor", "iter", or boolean

--- a/lua/spellwarn/init.lua
+++ b/lua/spellwarn/init.lua
@@ -2,9 +2,7 @@ local M = {}
 local defaults = {
     -- FIX: Trouble.nvim jump to diagnostic is slightly buggy with `TextChanged` event; no good workaround though AFAICT
     event = { -- event(s) to refresh diagnostics on
-        "TextChanged",
-        "InsertLeave",
-        "BufReadPost", -- Update after initial buffer render to set the scene.
+        "CursorHold", -- Relaxed updates, but also captures spelling setting being toggled.
     },
     enable = true, -- enable diagnostics on startup
     ft_config = { -- spellcheck method: "cursor", "iter", or boolean

--- a/lua/spellwarn/init.lua
+++ b/lua/spellwarn/init.lua
@@ -7,19 +7,19 @@ local defaults = {
     },
     enable = true, -- enable diagnostics on startup
     ft_config = { -- spellcheck method: "cursor", "iter", or boolean
-        alpha   = false,
-        help    = false,
-        lazy    = false,
+        alpha = false,
+        help = false,
+        lazy = false,
         lspinfo = false,
-        mason   = false,
+        mason = false,
     },
     ft_default = true, -- default option for unspecified filetypes
     max_file_size = nil, -- maximum file size to check in lines (nil for no limit)
     severity = { -- severity for each spelling error type (false to disable diagnostics for that type)
-        spellbad   = "WARN",
-        spellcap   = "HINT",
+        spellbad = "WARN",
+        spellcap = "HINT",
         spelllocal = "HINT",
-        spellrare  = "INFO",
+        spellrare = "INFO",
     },
     suggest = false, -- show spelling suggestions in diagnostic message
     num_suggest = 3, -- number of suggestions shown in diagnostic message

--- a/lua/spellwarn/init.lua
+++ b/lua/spellwarn/init.lua
@@ -4,6 +4,7 @@ local defaults = {
     event = { -- event(s) to refresh diagnostics on
         "TextChanged",
         "InsertLeave",
+        "BufReadPost", -- Update after initial buffer render to set the scene.
     },
     enable = true, -- enable diagnostics on startup
     ft_config = { -- spellcheck method: "cursor", "iter", or boolean

--- a/lua/spellwarn/init.lua
+++ b/lua/spellwarn/init.lua
@@ -2,7 +2,11 @@ local M = {}
 local defaults = {
     -- FIX: Trouble.nvim jump to diagnostic is slightly buggy with `TextChanged` event; no good workaround though AFAICT
     event = { -- event(s) to refresh diagnostics on
-        "CursorHold", -- Relaxed updates, but also captures spelling setting being toggled.
+        "CursorHold",
+        "InsertLeave",
+        "TextChanged",
+        "TextChangedI",
+        "TextChangedP",
     },
     enable = true, -- enable diagnostics on startup
     ft_config = { -- spellcheck method: "cursor", "iter", or boolean

--- a/lua/spellwarn/spelling.lua
+++ b/lua/spellwarn/spelling.lua
@@ -18,13 +18,15 @@ end
 
 function M.get_spelling_errors_main(opts, bufnr)
     local bufopts = opts.ft_config[vim.o.filetype] or opts.ft_default
-    local disable_comment =  string.find(vim.fn.getline(1) .. vim.fn.getline(2), "spellwarn:disable", 1, true) ~= nil
+    local disable_comment = string.find(vim.fn.getline(1) .. vim.fn.getline(2), "spellwarn:disable", 1, true) ~= nil
 
-    if vim.api.nvim_get_mode().mode == "i" or
-        disable_comment or
-        not bufopts or
-        not vim.o.spell or
-        vim.o.buftype == "terminal" then
+    if
+        vim.api.nvim_get_mode().mode == "i"
+        or disable_comment
+        or not bufopts
+        or not vim.o.spell
+        or vim.o.buftype == "terminal"
+    then
         return {}
     elseif bufopts == true or bufopts == "cursor" then
         return M.get_spelling_errors_cursor(bufnr)
@@ -51,10 +53,12 @@ function M.get_spelling_errors_cursor(bufnr)
     local location = vim.fn.getpos(".")
 
     local function adjust_table() -- Add error to table
-        if M.check_spellwarn_comment(0, vim.fn.line(".")) then return end
+        if M.check_spellwarn_comment(0, vim.fn.line(".")) then
+            return
+        end
         local word = vim.fn.expand("<cword>")
         table.insert(errors, {
-            col  = location[3],
+            col = location[3],
             lnum = location[2],
             type = M.get_error_type(word, bufnr),
             word = word,
@@ -82,10 +86,18 @@ function M.get_spelling_errors_cursor(bufnr)
 end
 
 function M.get_spelling_errors_iter(bufnr, start_row, start_col, end_row, end_col)
-    if start_row == nil then start_row = 0 end
-    if start_col == nil then start_col = 0 end
-    if end_row == nil then end_row = #(vim.api.nvim_buf_get_lines(bufnr, 1, -1, false)) + 1 end
-    if end_col == nil then end_col = string.len(vim.api.nvim_buf_get_lines(bufnr, end_row - 1, end_row, false)[1]) end
+    if start_row == nil then
+        start_row = 0
+    end
+    if start_col == nil then
+        start_col = 0
+    end
+    if end_row == nil then
+        end_row = #(vim.api.nvim_buf_get_lines(bufnr, 1, -1, false)) + 1
+    end
+    if end_col == nil then
+        end_col = string.len(vim.api.nvim_buf_get_lines(bufnr, end_row - 1, end_row, false)[1])
+    end
     local lines = vim.api.nvim_buf_get_lines(bufnr, start_row, end_row + 1, false)
     lines[#lines] = string.sub(lines[#lines], 1, end_col + 1)
     lines[1] = string.sub(lines[1], start_col + 1)
@@ -114,16 +126,22 @@ function M.get_spelling_errors_ts(bufnr)
     local ts_enabled = pcall(require, "nvim-treesitter")
     local buf_highlighter = ts_enabled and vim.treesitter.highlighter.active[bufnr]
 
-    if not buf_highlighter then return M.get_spelling_errors_iter(bufnr) end
+    if not buf_highlighter then
+        return M.get_spelling_errors_iter(bufnr)
+    end
     buf_highlighter.tree:for_each_tree(function(tstree, tree)
         ---@diagnostic disable: invisible
-        if not tstree then return end
+        if not tstree then
+            return
+        end
         local root = tstree:root()
 
         local q = buf_highlighter:get_query(tree:lang())
 
         -- Some injected languages may not have highlight queries.
-        if not q:query() then return end
+        if not q:query() then
+            return
+        end
 
         for capture, node in q:query():iter_captures(root, bufnr, 0, -1) do
             local c = q._query.captures[capture] -- Name of the capture in the query

--- a/lua/spellwarn/spelling.lua
+++ b/lua/spellwarn/spelling.lua
@@ -45,9 +45,9 @@ function M.get_spelling_errors_cursor(bufnr)
     -- Get location of first spelling error to start while loop
     vim.o.foldenable = false
     vim.o.conceallevel = 0
-    vim.fn.setpos(".", { bufnr, 1, 2, 0 })
+    vim.cmd('keepjumps call setpos(".", [0, 1,2,0])')
     local minpos = vim.fn.getpos(".")
-    vim.cmd("silent normal! ]s")
+    vim.cmd("silent keepjumps normal! ]s")
     local location = vim.fn.getpos(".")
 
     local function adjust_table() -- Add error to table
@@ -65,7 +65,7 @@ function M.get_spelling_errors_cursor(bufnr)
     while (minpos[2] < location[2]) or (minpos[2] == location[2] and minpos[3] < location[3]) do
         adjust_table()
         minpos = vim.fn.getpos(".")
-        vim.cmd("silent normal! ]s")
+        vim.cmd("silent keepjumps normal! ]s")
         location = vim.fn.getpos(".")
     end
 


### PR DESCRIPTION
When signcolumn has an "auto" setting this causes a UI redraw event that resizes the gutter inwards due to there being less icons in the gutter.  Next, repopulating the diagnostics causes another UI redraw to resize the gutter back outwards to account for the re-adding of all the spellwarn diagnostics.  This is a rapid visual glitch.

Diagnostics doesn't require a reset for NeoVim to automatically remove the entries that are no longer in the newly set diagnostics list of a namespace (at least in NeoVim v12), thus the reset function is unnecessary, and only serves to create visual glitching with every spelling mistake fixed or created when the signcolumn width is "auto".